### PR TITLE
Move ParaTranz translations from forceload/ to load/

### DIFF
--- a/src/gtnh_translation_compare/cmd/action.py
+++ b/src/gtnh_translation_compare/cmd/action.py
@@ -129,7 +129,7 @@ class Action:
         subdirectory: Path,
     ) -> list[str]:
         # Existing projects use resource folder on PT
-        path_converter_: ParatranzToLocalPathConverter = lambda path: Path('config/txloader/forceload') / os.path.relpath(path, Path('resources'))
+        path_converter_: ParatranzToLocalPathConverter = lambda path: Path('config/txloader/load') / os.path.relpath(path, Path('resources'))
 
         return await self.__paratranz_to_translation(
                 is_mod_lang_file,

--- a/src/gtnh_translation_compare/cmd/action.py
+++ b/src/gtnh_translation_compare/cmd/action.py
@@ -2,6 +2,7 @@ import asyncio
 import datetime
 import glob
 import os
+import re
 import shutil
 from pathlib import Path
 import subprocess
@@ -129,7 +130,10 @@ class Action:
         subdirectory: Path,
     ) -> list[str]:
         # Existing projects use resource folder on PT
-        path_converter_: ParatranzToLocalPathConverter = lambda path: Path('config/txloader/load') / os.path.relpath(path, Path('resources'))
+        def path_converter_(path: str) -> Path:
+            rel = Path(os.path.relpath(path, Path('resources')))
+            domain = re.sub(r'^.*\[([^\]]+)\]$', r'\1', rel.parts[0])
+            return Path('config/txloader/load') / domain / Path(*rel.parts[1:])
 
         return await self.__paratranz_to_translation(
                 is_mod_lang_file,


### PR DESCRIPTION
TX-Loader 1.8.7+ (PR https://github.com/GTNewHorizons/TX-Loader/pull/19) made `load/` override mod jars. ParaTranz translations were in `forceload/` alongside `____gtnhoverridenames`, competing at the same priority level with no guaranteed order (HashSet). Moving them to `load/` leaves `forceload/` exclusively for override names, fixing items like Obzinite showing the old Alumite name in Russian.