### PR TITLE
files uploaded manually to ParaTranz have no extra field, skip with warning instead of crashing

### DIFF
--- a/src/gtnh_translation_compare/cmd/action.py
+++ b/src/gtnh_translation_compare/cmd/action.py
@@ -62,6 +62,8 @@ class Action:
         for f in all_files:
             if filter_(f.name):
                 translation_file = await self.converter.to_translation_file(f)
+                if translation_file is None:
+                    continue
                 if after_to_translation_file_callback is not None:
                     after_to_translation_file_callback(translation_file)
                 translation_files.append(translation_file)

--- a/src/gtnh_translation_compare/paratranz/converter.py
+++ b/src/gtnh_translation_compare/paratranz/converter.py
@@ -1,5 +1,5 @@
 from io import StringIO
-from typing import List, Tuple, Dict
+from typing import List, Tuple, Dict, Optional
 
 from loguru import logger
 
@@ -24,19 +24,24 @@ class Converter:
         self.cache = cache
         self.target_lang = target_lang
 
-    async def to_translation_file(self, paratranz_file: File) -> "TranslationFile":
+    async def to_translation_file(self, paratranz_file: File) -> "Optional[TranslationFile]":
         cached = self.cache.get(paratranz_file)
         if cached:
             logger.info("cache hit: {}", paratranz_file.name)
             return cached
         translation_file = await self._to_translation_file(paratranz_file)
+        if translation_file is None:
+            return None
         self.cache.set(paratranz_file, translation_file)
         logger.info("cache miss: {}", paratranz_file.name)
         return translation_file
 
-    async def _to_translation_file(self, paratranz_file: File) -> "TranslationFile":
+    async def _to_translation_file(self, paratranz_file: File) -> "Optional[TranslationFile]":
         paratranz_file = await self.client.get_file(paratranz_file.id)
         file_extra_dict = paratranz_file.extra
+        if file_extra_dict is None:
+            logger.warning("skipping file with no extra metadata (uploaded manually?): {}", paratranz_file.name)
+            return None
         file_extra = FileExtra.model_validate(file_extra_dict)
         content = file_extra.original
         string_items = await self.client.get_strings(paratranz_file.id)

--- a/src/gtnh_translation_compare/paratranz/converter.py
+++ b/src/gtnh_translation_compare/paratranz/converter.py
@@ -40,6 +40,7 @@ class Converter:
         paratranz_file = await self.client.get_file(paratranz_file.id)
         file_extra_dict = paratranz_file.extra
         if file_extra_dict is None:
+            print(f"::warning::skipping ParaTranz file with no extra metadata (uploaded manually?): {paratranz_file.name}")
             logger.warning("skipping file with no extra metadata (uploaded manually?): {}", paratranz_file.name)
             return None
         file_extra = FileExtra.model_validate(file_extra_dict)


### PR DESCRIPTION
ParaTranz files uploaded manually via the web UI don't have the `extra` metadata field that this repo's sync workflow sets when uploading files. The converter crashed with a ValidationError when it encountered such a file.

Fixed by skipping files without `extra` instead of crashing. A GitHub Actions warning annotation is shown with the file name so it's visible on the run page without digging into logs.

Affected languages in the failing run: zh_CN, fr_FR, es_ES. The files causing the issue were likely uploaded directly in ParaTranz by translators, bypassing the sync workflow.