### PR TITLE
skip files with invalid extra metadata instead of crashing

### DIFF
--- a/src/gtnh_translation_compare/paratranz/converter.py
+++ b/src/gtnh_translation_compare/paratranz/converter.py
@@ -43,7 +43,12 @@ class Converter:
             print(f"::warning::skipping ParaTranz file with no extra metadata (uploaded manually?): {paratranz_file.name}")
             logger.warning("skipping file with no extra metadata (uploaded manually?): {}", paratranz_file.name)
             return None
-        file_extra = FileExtra.model_validate(file_extra_dict)
+        try:
+            file_extra = FileExtra.model_validate(file_extra_dict)
+        except Exception as e:
+            print(f"::warning::skipping ParaTranz file with invalid extra metadata: {paratranz_file.name} ({e})")
+            logger.warning("skipping file with invalid extra metadata: {} ({})", paratranz_file.name, e)
+            return None
         content = file_extra.original
         string_items = await self.client.get_strings(paratranz_file.id)
         string_items_map = {item.key: item for item in string_items}


### PR DESCRIPTION
zh_CN sync crashed with a pydantic ValidationError because a file had an `extra` dict with only `original` and `start` fields, missing `en_us_relpath` and `target_relpath`. The existing None check from PR #71 didn't catch this case.

Fixed by wrapping `FileExtra.model_validate` in a try/except and skipping the file with a warning annotation, same pattern as the None extra check.