### PR TITLE
Compatibility for zh_CN

### DIFF
--- a/src/gtnh_translation_compare/paratranz/types.py
+++ b/src/gtnh_translation_compare/paratranz/types.py
@@ -61,10 +61,12 @@ class FileExtra(BaseModel):
                     logger.warning(f"FileExtra.{legacy_key} is deprecated, use FileExtra.target_relpath instead")
             if "enUsRelpath" in data:
                 data["en_us_relpath"] = data["enUsRelpath"]
-                logger.warning(f"Compatibility for enUsRelpath")
+                data.pop("enUsRelpath")
+                logger.warning("Compatibility for enUsRelpath")
             if "targetRelpath" in data:
                 data["target_relpath"] = data["targetRelpath"]
-                logger.warning(f"Compatibility for targetRelpath")
+                data.pop("targetRelpath")
+                logger.warning("Compatibility for targetRelpath")
         return data
 
 

--- a/src/gtnh_translation_compare/paratranz/types.py
+++ b/src/gtnh_translation_compare/paratranz/types.py
@@ -59,6 +59,12 @@ class FileExtra(BaseModel):
                     data["target_relpath"] = data[legacy_key]
                     data.pop(legacy_key)
                     logger.warning(f"FileExtra.{legacy_key} is deprecated, use FileExtra.target_relpath instead")
+            if "enUsRelpath" in data:
+                data["en_us_relpath"] = data["enUsRelpath"]
+                logger.warning(f"Compatibility for enUsRelpath")
+            if "targetRelpath" in data:
+                data["target_relpath"] = data["targetRelpath"]
+                logger.warning(f"Compatibility for targetRelpath")
         return data
 
 


### PR DESCRIPTION
`zh_CN` use (https://github.com/MuXiu1997/GTNH-translation-compare/tree/next) for syncing to paratranz which use different naming scheme.

This PR introduce compatibility between the 2 different namings.