### PR TITLE
Implement line break substitution

### DIFF
--- a/src/gtnh_translation_compare/paratranz/converter.py
+++ b/src/gtnh_translation_compare/paratranz/converter.py
@@ -15,6 +15,7 @@ from gtnh_translation_compare.paratranz.types import (
     Property,
     StringItem,
 )
+from gtnh_translation_compare.utils.line_break_subst import line_break_subst
 from gtnh_translation_compare.utils.unicode import to_unicode
 
 
@@ -73,7 +74,7 @@ class Converter:
             translation = string_item.translation
             if translation:
                 buffer.write(content[left : p.start])
-                buffer.write(translation)
+                buffer.write(line_break_subst(string_item.context, translation))
             else:
                 buffer.write(content[left : p.end])
             left = p.end

--- a/src/gtnh_translation_compare/utils/line_break_subst.py
+++ b/src/gtnh_translation_compare/utils/line_break_subst.py
@@ -1,0 +1,30 @@
+import re
+from typing import Optional
+
+from loguru import logger
+
+LINE_BREAK_CONTEXT_PREFIX = "@gtnh-line-break-form="
+LINE_BREAK_CONTEXT_NOOP = "LF"
+LINE_BREAK_CONTEXT_DECODE_MAP = {
+  "<BR>-UP": "<BR>",
+  "<BR>": "<br>",
+  "[br]": "[br]",
+  "\\\\n": "\\\\n",
+  "\\n": "\\n",
+  "%n": "%n",
+}
+
+
+def line_break_subst(context: Optional[str], translation: str) -> str:
+  if context is None: return translation
+  sp_ctx: list[str] = re.split(r'\r?\n', context)
+  for ctx_line in sp_ctx:
+    if not ctx_line.startswith(LINE_BREAK_CONTEXT_PREFIX): continue
+    norm_to_entry = ctx_line[len(LINE_BREAK_CONTEXT_PREFIX):]
+    if norm_to_entry == LINE_BREAK_CONTEXT_NOOP: return translation
+    if norm_to_entry not in LINE_BREAK_CONTEXT_DECODE_MAP:
+      logger.warn(f"Not recognized for line break: {norm_to_entry}")
+      return translation
+    norm_to = LINE_BREAK_CONTEXT_DECODE_MAP[norm_to_entry]
+    return re.sub(r'\r?\n', norm_to, translation)
+  return translation


### PR DESCRIPTION
When the context contains `@gtnh-line-break-form=xxx`, automatically convert the line break into the specified format in the lang file.