### PR TITLE
Bump softprops/action-gh-release to v3 for node24

### DIFF
--- a/.github/workflows/publish-daily-lang-pack.yml
+++ b/.github/workflows/publish-daily-lang-pack.yml
@@ -117,7 +117,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Release as Latest
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: ${{ inputs.target_lang }}-latest
           name: ${{ inputs.target_lang }} Latest

--- a/.github/workflows/publish-daily-lang-pack.yml
+++ b/.github/workflows/publish-daily-lang-pack.yml
@@ -117,7 +117,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Release as Latest
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.target_lang }}-latest
           name: ${{ inputs.target_lang }} Latest


### PR DESCRIPTION
PR #85 bumped most actions to node24 versions but missed softprops/action-gh-release, which still triggered "Node.js 20 is deprecated" warnings in the daily lang pack builds. The whole v2 line (including latest v2.6.2) runs on node20; node24 only ships in v3, so this bumps it to v3. We only use tag_name/name/files/token, which are unchanged in v3, so no breaking changes for our usage.

This clears the 5 Node.js 20 deprecation warnings. The remaining "skipping ParaTranz file with no extra metadata" warnings are unrelated (application logic for manually uploaded files) and left as-is intentionally.