### PR TITLE
Support GregTech markdown tooltips in the ParaTranz sync pipeline

### DIFF
--- a/src/gtnh_translation_compare/cmd/action.py
+++ b/src/gtnh_translation_compare/cmd/action.py
@@ -14,7 +14,14 @@ from dulwich import porcelain
 from loguru import logger
 
 from gtnh_translation_compare import settings
-from gtnh_translation_compare.filetypes import FiletypeLang, Language, FiletypeGTLang, Filetype
+from gtnh_translation_compare.filetypes import (
+    FiletypeLang,
+    Language,
+    FiletypeGTLang,
+    FiletypeMarkdownTooltip,
+    Filetype,
+    is_markdown_tooltip_path,
+)
 from gtnh_translation_compare.modpack.modpack import ModPack
 from gtnh_translation_compare.paratranz.client_wrapper import ClientWrapper
 from gtnh_translation_compare.paratranz.converter import Converter
@@ -25,6 +32,12 @@ from gtnh_translation_compare.utils.file import ensure_lf
 ParatranzFilenameFilter: TypeAlias = Callable[[str], bool]
 ParatranzToLocalPathConverter: TypeAlias = Callable[[str], Path]
 AfterToTranslationFileCallback: TypeAlias = Callable[[TranslationFile], None]
+
+
+def _make_lang_or_markdown_filetype(relpath: str, content: str) -> Filetype:
+    if is_markdown_tooltip_path(relpath):
+        return FiletypeMarkdownTooltip(relpath, content)
+    return FiletypeLang(relpath, content)
 
 
 class Action:
@@ -290,7 +303,7 @@ class Action:
                 continue
             with open(base_path / file_path, 'r', encoding='UTF-8') as f:
                 content = f.read()
-            lang_files.append(FiletypeLang(file_path, content))
+            lang_files.append(_make_lang_or_markdown_filetype(file_path, content))
 
         # concurrency number
         sem = asyncio.Semaphore(10)
@@ -332,6 +345,10 @@ class Action:
             with open(file_path, 'r', encoding='UTF-8') as f:
                 content = f.read()
             lang_files.append(FiletypeLang(os.path.relpath(file_path, base_path), content))
+        for file_path in glob.glob(f'./{base_path}/resources/*/lang/en_US/tooltip/**/*.md', recursive=True):
+            with open(file_path, 'r', encoding='UTF-8') as f:
+                content = f.read()
+            lang_files.append(FiletypeMarkdownTooltip(os.path.relpath(file_path, base_path), content))
 
         # concurrency number
         sem = asyncio.Semaphore(10)

--- a/src/gtnh_translation_compare/filetypes/__init__.py
+++ b/src/gtnh_translation_compare/filetypes/__init__.py
@@ -1,6 +1,10 @@
 from gtnh_translation_compare.filetypes.filetype import Filetype
 from gtnh_translation_compare.filetypes.filetype_gt_lang import FiletypeGTLang
 from gtnh_translation_compare.filetypes.filetype_lang import FiletypeLang
+from gtnh_translation_compare.filetypes.filetype_markdown_tooltip import (
+    FiletypeMarkdownTooltip,
+    is_markdown_tooltip_path,
+)
 from gtnh_translation_compare.filetypes.language import Language
 from gtnh_translation_compare.filetypes.property import Property
 
@@ -8,6 +12,8 @@ __all__ = [
     "Filetype",
     "FiletypeGTLang",
     "FiletypeLang",
+    "FiletypeMarkdownTooltip",
+    "is_markdown_tooltip_path",
     "Language",
     "Property",
 ]

--- a/src/gtnh_translation_compare/filetypes/filetype_markdown_tooltip.py
+++ b/src/gtnh_translation_compare/filetypes/filetype_markdown_tooltip.py
@@ -1,0 +1,54 @@
+from typing import Dict
+
+from gtnh_translation_compare.filetypes.filetype import Filetype
+from gtnh_translation_compare.filetypes.language import Language
+from gtnh_translation_compare.filetypes.property import Property
+
+# Path marker shared between mod.py's jar scanner and the daily-sync workflow's
+# changed-file dispatcher, so both agree on what counts as a markdown tooltip file.
+MARKDOWN_TOOLTIP_PATH_MARKER = "/lang/{language}/tooltip/"
+
+
+def is_markdown_tooltip_path(relpath: str, language: Language = Language.en_US) -> bool:
+    return MARKDOWN_TOOLTIP_PATH_MARKER.format(language=language.value) in relpath and relpath.endswith(".md")
+
+
+class FiletypeMarkdownTooltip(Filetype):
+    """
+    A GregTech "markdown" tooltip file (`assets/<mod>/lang/<locale>/tooltip/<slug>.md`),
+    loaded by `MarkdownTooltipLoader` in-game. Unlike `.lang`, there is no key=value
+    structure at all: the whole file is free-form prose interleaved with `{command}`
+    markup, addressed by its file path rather than by a key inside it.
+
+    We therefore treat the entire file content as a single translatable unit, keyed by
+    its own relpath. This lets translators see and reflow the whole tooltip as one
+    coherent text (important for languages with different word order), and matches how
+    GregTech itself treats the file: one path, one blob of text, no inner key.
+    """
+
+    def __init__(self, relpath: str, content: str, language: Language = Language.en_US):
+        self._relpath = relpath
+        self._content = content
+        self._language = language
+
+    def _get_relpath(self) -> str:
+        return self._relpath
+
+    def _get_content(self) -> str:
+        return self._content
+
+    def _get_properties(self, content: str) -> Dict[str, Property]:
+        if content == "":
+            return {}
+        key = f"md-tooltip|{self._relpath}"
+        return {key: Property(key=key, value=content, full=content, start=0, end=len(content))}
+
+    def get_en_us_relpath(self) -> str:
+        if self._language == Language.en_US:
+            return self._relpath
+        return self._relpath.replace(self._language.value, Language.en_US.value)
+
+    def get_target_language_relpath(self, target_language: Language) -> str:
+        if self._language == target_language:
+            return self._relpath
+        return self._relpath.replace(self._language.value, target_language.value)

--- a/src/gtnh_translation_compare/modpack/mod.py
+++ b/src/gtnh_translation_compare/modpack/mod.py
@@ -36,3 +36,19 @@ class Mod:
                 with self.__jar.open(f, mode="r") as fp:
                     lang_files[f] = ensure_lf(fp.read().decode("utf-8-sig", errors="ignore"))
         return lang_files
+
+    @cache
+    def markdown_tooltip_files(self, language: Language) -> Dict[Filename, Content]:
+        markdown_files = {}
+        for f in self.__jar.namelist():
+            parts = f.split("/")
+            # assets/<modid>/lang/<language>/tooltip/<slug...>.md (nested slugs allowed)
+            if len(parts) < 6:
+                continue
+            if parts[0] != "assets" or parts[2] != "lang" or parts[3] != language.name or parts[4] != "tooltip":
+                continue
+            if not f.endswith(".md"):
+                continue
+            with self.__jar.open(f, mode="r") as fp:
+                markdown_files[f] = ensure_lf(fp.read().decode("utf-8-sig", errors="ignore"))
+        return markdown_files

--- a/src/gtnh_translation_compare/modpack/modpack.py
+++ b/src/gtnh_translation_compare/modpack/modpack.py
@@ -4,7 +4,7 @@ from functools import cache
 from os import path
 from typing import Sequence
 
-from gtnh_translation_compare.filetypes import Filetype, FiletypeLang
+from gtnh_translation_compare.filetypes import Filetype, FiletypeLang, FiletypeMarkdownTooltip
 from gtnh_translation_compare.filetypes.language import Language
 from gtnh_translation_compare.modpack.mod import Mod
 from gtnh_translation_compare.utils.file import ensure_lf
@@ -21,7 +21,7 @@ class ModPack:
 
     @cache
     def lang_files(self, language: Language) -> Sequence[Filetype]:
-        lang_files: list[FiletypeLang] = []
+        lang_files: list[Filetype] = []
         for mod_path in self.__pack_path.glob("mods/**/*.jar"):
             with mod_path.open("rb") as mod_jar:
                 mod = Mod(zipfile.ZipFile(mod_jar))
@@ -29,4 +29,10 @@ class ModPack:
                     sub_mod_id = filename.split("/")[1]
                     filename = path.join(*filename.split("/")[2:])
                     lang_files.append(FiletypeLang(f"resources/{mod.mod_name}[{sub_mod_id}]/{filename}", content))
+                for filename, content in mod.markdown_tooltip_files(language).items():
+                    sub_mod_id = filename.split("/")[1]
+                    filename = path.join(*filename.split("/")[2:])
+                    lang_files.append(
+                        FiletypeMarkdownTooltip(f"resources/{mod.mod_name}[{sub_mod_id}]/{filename}", content)
+                    )
         return lang_files

--- a/tests/filetypes/test_filetype_markdown_tooltip.py
+++ b/tests/filetypes/test_filetype_markdown_tooltip.py
@@ -1,0 +1,85 @@
+from gtnh_translation_compare.filetypes import FiletypeMarkdownTooltip, Language, Property, is_markdown_tooltip_path
+import pytest
+
+EN_US_RELPATH = "resources/GregTech[gregtech]/lang/en_US/tooltip/bec-ionode.md"
+EN_US_CONTENT = "\n".join(
+    [
+        "Teleports items into and out of the {gold:{item:gregtech:gt.blockmachines:15756}}.",
+        "Recipe logic is the same as all other multiblocks.",
+    ]
+)
+RU_RU_RELPATH = "resources/GregTech[gregtech]/lang/ru_RU/tooltip/bec-ionode.md"
+RU_RU_CONTENT = "\n".join(
+    [
+        "Телепортирует предметы в {gold:{item:gregtech:gt.blockmachines:15756}} и обратно.",
+        "Логика рецептов такая же, как и у всех других мультиблоков.",
+    ]
+)
+
+
+@pytest.fixture(scope="module")
+def en_us_filetype_markdown_tooltip() -> FiletypeMarkdownTooltip:
+    return FiletypeMarkdownTooltip(EN_US_RELPATH, EN_US_CONTENT)
+
+
+@pytest.fixture(scope="module")
+def ru_ru_filetype_markdown_tooltip() -> FiletypeMarkdownTooltip:
+    return FiletypeMarkdownTooltip(RU_RU_RELPATH, RU_RU_CONTENT, Language.ru_RU)
+
+
+def test__get_relpath(
+    en_us_filetype_markdown_tooltip: FiletypeMarkdownTooltip,
+    ru_ru_filetype_markdown_tooltip: FiletypeMarkdownTooltip,
+) -> None:
+    assert en_us_filetype_markdown_tooltip.relpath == EN_US_RELPATH
+    assert ru_ru_filetype_markdown_tooltip.relpath == RU_RU_RELPATH
+
+
+def test__get_content(
+    en_us_filetype_markdown_tooltip: FiletypeMarkdownTooltip,
+    ru_ru_filetype_markdown_tooltip: FiletypeMarkdownTooltip,
+) -> None:
+    assert en_us_filetype_markdown_tooltip.content == EN_US_CONTENT
+    assert ru_ru_filetype_markdown_tooltip.content == RU_RU_CONTENT
+
+
+def test__get_properties(
+    en_us_filetype_markdown_tooltip: FiletypeMarkdownTooltip,
+    ru_ru_filetype_markdown_tooltip: FiletypeMarkdownTooltip,
+) -> None:
+    # The whole file is a single translation unit, keyed by its own relpath.
+    key = f"md-tooltip|{EN_US_RELPATH}"
+    assert en_us_filetype_markdown_tooltip.properties == {
+        key: Property(key, EN_US_CONTENT, EN_US_CONTENT, 0, len(EN_US_CONTENT)),
+    }
+    ru_key = f"md-tooltip|{RU_RU_RELPATH}"
+    assert ru_ru_filetype_markdown_tooltip.properties == {
+        ru_key: Property(ru_key, RU_RU_CONTENT, RU_RU_CONTENT, 0, len(RU_RU_CONTENT)),
+    }
+
+
+def test__get_properties_empty_file() -> None:
+    assert FiletypeMarkdownTooltip(EN_US_RELPATH, "").properties == {}
+
+
+def test_get_en_us_relpath(
+    en_us_filetype_markdown_tooltip: FiletypeMarkdownTooltip,
+    ru_ru_filetype_markdown_tooltip: FiletypeMarkdownTooltip,
+) -> None:
+    assert en_us_filetype_markdown_tooltip.get_en_us_relpath() == EN_US_RELPATH
+    assert ru_ru_filetype_markdown_tooltip.get_en_us_relpath() == EN_US_RELPATH
+
+
+def test_get_target_relpath(
+    en_us_filetype_markdown_tooltip: FiletypeMarkdownTooltip,
+    ru_ru_filetype_markdown_tooltip: FiletypeMarkdownTooltip,
+) -> None:
+    assert en_us_filetype_markdown_tooltip.get_target_language_relpath(Language.ru_RU) == RU_RU_RELPATH
+    assert ru_ru_filetype_markdown_tooltip.get_target_language_relpath(Language.en_US) == EN_US_RELPATH
+
+
+def test_is_markdown_tooltip_path() -> None:
+    assert is_markdown_tooltip_path(EN_US_RELPATH)
+    assert not is_markdown_tooltip_path(RU_RU_RELPATH)  # default language arg is en_US
+    assert is_markdown_tooltip_path(RU_RU_RELPATH, Language.ru_RU)
+    assert not is_markdown_tooltip_path("resources/GregTech[gregtech]/lang/en_US.lang")


### PR DESCRIPTION
GregTech is moving some multiblock tooltip text from per-line lang keys to markdown files (assets/<mod>/lang/<locale>/tooltip/<slug>.md, loaded by MarkdownTooltipLoader). These files have no key=value structure of their own, only free-form prose interleaved with {command} markup, so the existing FiletypeLang parser can't see them and they currently don't reach ParaTranz at all.

Adds FiletypeMarkdownTooltip, treating the whole file as a single translation unit keyed by its relpath (no per-line key exists to hang a stable identifier on, and this lets translators reflow the whole tooltip instead of being pinned to English sentence boundaries). Wires it into Mod/ModPack jar scanning and both the conditional and full sync-to-ParaTranz actions, alongside the existing FiletypeLang path.