### PR TITLE
Un-escape literal \n in downloaded markdown tooltip translations

### DIFF
--- a/src/gtnh_translation_compare/cmd/action.py
+++ b/src/gtnh_translation_compare/cmd/action.py
@@ -21,6 +21,7 @@ from gtnh_translation_compare.filetypes import (
     FiletypeMarkdownTooltip,
     Filetype,
     is_markdown_tooltip_path,
+    is_markdown_tooltip_paratranz_file,
 )
 from gtnh_translation_compare.modpack.modpack import ModPack
 from gtnh_translation_compare.paratranz.client_wrapper import ClientWrapper
@@ -504,11 +505,6 @@ def is_mod_lang_file(name: str) -> bool:
             and name != settings.GT_LANG_TARGET_REL_PATH + ".json",
         ]
     )
-
-
-def is_markdown_tooltip_paratranz_file(name: str) -> bool:
-    # ParaTranz always appends ".json" to the original file's relpath.
-    return is_markdown_tooltip_path(name.removesuffix(".json"))
 
 
 def _resources_to_txloader_path(path: str) -> Path:

--- a/src/gtnh_translation_compare/filetypes/__init__.py
+++ b/src/gtnh_translation_compare/filetypes/__init__.py
@@ -4,6 +4,7 @@ from gtnh_translation_compare.filetypes.filetype_lang import FiletypeLang
 from gtnh_translation_compare.filetypes.filetype_markdown_tooltip import (
     FiletypeMarkdownTooltip,
     is_markdown_tooltip_path,
+    is_markdown_tooltip_paratranz_file,
 )
 from gtnh_translation_compare.filetypes.language import Language
 from gtnh_translation_compare.filetypes.property import Property
@@ -14,6 +15,7 @@ __all__ = [
     "FiletypeLang",
     "FiletypeMarkdownTooltip",
     "is_markdown_tooltip_path",
+    "is_markdown_tooltip_paratranz_file",
     "Language",
     "Property",
 ]

--- a/src/gtnh_translation_compare/filetypes/filetype_markdown_tooltip.py
+++ b/src/gtnh_translation_compare/filetypes/filetype_markdown_tooltip.py
@@ -16,6 +16,11 @@ def is_markdown_tooltip_path(relpath: str) -> bool:
     return MARKDOWN_TOOLTIP_PATH_RE.search(relpath) is not None
 
 
+def is_markdown_tooltip_paratranz_file(name: str) -> bool:
+    # ParaTranz always appends ".json" to the original file's relpath.
+    return is_markdown_tooltip_path(name.removesuffix(".json"))
+
+
 class FiletypeMarkdownTooltip(Filetype):
     """
     A GregTech "markdown" tooltip file (`assets/<mod>/lang/<locale>/tooltip/<slug>.md`),

--- a/src/gtnh_translation_compare/utils/line_break_subst.py
+++ b/src/gtnh_translation_compare/utils/line_break_subst.py
@@ -4,6 +4,7 @@ from typing import Optional
 from loguru import logger
 
 from gtnh_translation_compare import settings
+from gtnh_translation_compare.filetypes.filetype_markdown_tooltip import is_markdown_tooltip_paratranz_file
 from gtnh_translation_compare.paratranz.types import File
 
 LINE_BREAK_CONTEXT_PREFIX = "@gtnh-line-break-form="
@@ -37,6 +38,14 @@ def get_line_break_symbol(dflt_setting: Optional[str], context: Optional[str]) -
 
 
 def line_break_subst(file: File, context: Optional[str], translation: str) -> str:
+  if is_markdown_tooltip_paratranz_file(file.name):
+    # Markdown tooltips are translated as a single multi-line blob (see
+    # FiletypeMarkdownTooltip), but ParaTranz's editor for this kind of string turns
+    # Enter (and Shift+Enter) into a literal "\n" instead of a real line break, no
+    # matter what the translator does. The .md format needs real line breaks
+    # (GregTech reads it with readLines()), so un-escape it here instead of relying
+    # on the translator typing something the site's UI can't actually produce.
+    return translation.replace("\\r\\n", "\n").replace("\\n", "\n")
   dflt_sym = None
   if file.name == settings.GT_LANG_TARGET_REL_PATH + ".json":
     dflt_sym = "<BR>"

--- a/tests/utils/test_line_break_subst.py
+++ b/tests/utils/test_line_break_subst.py
@@ -1,0 +1,26 @@
+from gtnh_translation_compare.paratranz.types import File
+from gtnh_translation_compare.utils.line_break_subst import line_break_subst
+
+
+def test_markdown_tooltip_unescapes_literal_backslash_n() -> None:
+    # ParaTranz's editor turns Enter (and Shift+Enter) into a literal "\n" for these
+    # single-blob translations, no matter what the translator does, so this must
+    # un-escape it back into a real line break regardless of the file's context.
+    file = File(id=1, name="resources/GregTech[gregtech]/lang/ru_RU/tooltip/bec-ionode.md.json")
+    translation = "Первая строка.\\nВторая строка."
+    assert line_break_subst(file, None, translation) == "Первая строка.\nВторая строка."
+
+
+def test_markdown_tooltip_leaves_real_newlines_alone() -> None:
+    file = File(id=1, name="resources/GregTech[gregtech]/lang/ru_RU/tooltip/bec-ionode.md.json")
+    translation = "Первая строка.\nВторая строка."
+    assert line_break_subst(file, None, translation) == translation
+
+
+def test_non_markdown_file_is_unaffected() -> None:
+    file = File(id=1, name="resources/GregTech[gregtech]/lang/ru_RU.lang.json")
+    translation = "test\\ntest2"
+    # Not a markdown tooltip file: falls through to the existing NOOP behavior, which
+    # leaves the translation untouched (only real \r?\n gets substituted, and there
+    # isn't one here).
+    assert line_break_subst(file, None, translation) == translation


### PR DESCRIPTION
ParaTranz's editor turns Enter (and Shift+Enter) into a literal "\n" for these single-blob translations no matter what the translator does, but the .md format needs real line breaks.

line_break_subst now special-cases markdown tooltip files and un-escapes \n and \r\n back into real newlines, instead of assuming the translation already has real ones like every other file type does.

Also moves the shared is_markdown_tooltip_paratranz_file check into filetypes so line_break_subst can use it without action.py importing it back (would've been circular).