### PR TITLE
Deliver markdown tooltips under the bare mod domain, not .lang's folder

### DIFF
--- a/src/gtnh_translation_compare/cmd/action.py
+++ b/src/gtnh_translation_compare/cmd/action.py
@@ -167,7 +167,7 @@ class Action:
                 None,
                 repo_path,
                 subdirectory,
-                _resources_to_txloader_path,
+                _markdown_tooltip_to_txloader_path,
         )
 
     # Gt Lang
@@ -525,6 +525,28 @@ def _resources_to_txloader_path(path: str) -> Path:
         logger.warning(f"Unknown path {path}")
         provided = cfg / "txloader" / "load" / provided
     return provided
+
+
+MOD_DOMAIN_RE = re.compile(r"\[([^\[\]]+)\]$")
+
+
+def _markdown_tooltip_to_txloader_path(path: str) -> Path:
+    # Markdown tooltips only, never .lang: unlike .lang, a tooltip slug belongs to one mod,
+    # so collapsing "<DisplayName>[<domain>]" to the bare domain here is safe. Don't reuse
+    # this for _resources_to_txloader_path's job - addon mods contribute lines to another
+    # mod's .lang through their own bracketed folder, and collapsing those would drop one
+    # contributor's translations whenever two folders share a domain and relative path.
+    cfg = Path("config")
+    provided = Path(path)
+    parts = list(provided.parts)
+    if len(parts) < 2 or parts[0] != "resources":
+        logger.warning(f"Unknown path for markdown tooltip {path}")
+        return cfg / "txloader" / "load" / provided
+    match = MOD_DOMAIN_RE.search(parts[1])
+    if match is None:
+        logger.warning(f"Could not find mod domain in {parts[1]!r} for markdown tooltip {path}")
+        return cfg / "txloader" / "load" / Path(*parts[1:])
+    return cfg / "txloader" / "load" / match.group(1) / Path(*parts[2:])
 
 
 def print_yellow(string: str) -> None:


### PR DESCRIPTION
MarkdownTooltipLoader asks TXLoader for a resource by the mod's real domain. GTNH-Translations stores translations under a "<DisplayName>[<domain>]" folder instead. Regular .lang delivery survives this mismatch by accident: Minecraft's language bootstrap loads every resource pack's reported domain name, brackets included, and merges each file by key. That mechanism is also how an addon mod contributes extra lines to another mod's domain, through its own separate bracketed folder.

I tried fixing this in TXLoader (GTNewHorizons/TX-Loader#27, closed) and considered collapsing every bracketed folder for a domain into one physical folder. Both approaches drop one contributor's translations whenever two folders share a domain and a relative path, which happens in practice.

Markdown tooltip slugs belong to one mod each; no addon contributes lines to another mod's tooltip. This PR rewrites only the markdown delivery path to the bare domain folder. _resources_to_txloader_path, the .lang mechanism, stays untouched.