### PR TITLE
Fix GregTech.lang change flag not reaching daily-schedule

### DIFF
--- a/.github/workflows/save-daily-modpack-history.yml
+++ b/.github/workflows/save-daily-modpack-history.yml
@@ -2,6 +2,10 @@ name: Save daily modpack history
 
 on:
   workflow_call:
+    outputs:
+      gt_lang_changed:
+        description: "'true' if GregTech.lang changed in this run"
+        value: ${{ jobs.save-daily-modpack-history.outputs.gt_lang_changed }}
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
sync-gt-lang-to-paratranz-all-langs stayed skipped every day even when GregTech.lang genuinely changed (verified in the 2026-07-25 run: a real 564/782-line diff landed in daily-history/GregTech.lang, but the sync job below it in daily-schedule was still skipped).

Declaring outputs on save-daily-modpack-history's job isn't enough once that workflow is invoked with workflow_call from daily-schedule: a reusable workflow only exposes outputs that its own on.workflow_call.outputs block re-declares. Without that, needs.save-daily-modpack-history.outputs.gt_lang_changed in daily-schedule was always empty, so the == 'true' check never passed.