### PR TITLE
Dedupe ParaTranz sync output after path conversion

### DIFF
--- a/es_ES/config/txloader/load/BetterQuesting[CB4BQ]/lang/es_ES.lang
+++ b/es_ES/config/txloader/load/BetterQuesting[CB4BQ]/lang/es_ES.lang
@@ -1,4 +1,0 @@
-tile.CB4BQ.DLB.name=Bloque de Carga Por Defecto
-tile.CB4BQ.DSB.name=Bloque de Guardado Por Defecto
-tile.CB4BQ.HSB.name=Bloque de Cambio de Hardcore
-tile.CB4BQ.REB.name=Bloque de Reinicio de Misiones

--- a/es_ES/config/txloader/load/BetterQuesting[cb4bq]/lang/es_ES.lang
+++ b/es_ES/config/txloader/load/BetterQuesting[cb4bq]/lang/es_ES.lang
@@ -1,4 +1,4 @@
-tile.CB4BQ.DLB.name=Default Load Block
-tile.CB4BQ.DSB.name=Default Save Block
-tile.CB4BQ.HSB.name=Hardcore Switch Block
-tile.CB4BQ.REB.name=Reset Quest Block
+tile.CB4BQ.DLB.name=Bloque de Carga Por Defecto
+tile.CB4BQ.DSB.name=Bloque de Guardado Por Defecto
+tile.CB4BQ.HSB.name=Bloque de Cambio de Hardcore
+tile.CB4BQ.REB.name=Bloque de Reinicio de Misiones

--- a/fr_FR/config/txloader/load/BetterQuesting[CB4BQ]/lang/fr_FR.lang
+++ b/fr_FR/config/txloader/load/BetterQuesting[CB4BQ]/lang/fr_FR.lang
@@ -1,4 +1,0 @@
-tile.CB4BQ.DLB.name=Bloc de chargement par défaut
-tile.CB4BQ.DSB.name=Bloc de sauvegarde par défaut
-tile.CB4BQ.HSB.name=Bloc de commutation vers difficile
-tile.CB4BQ.REB.name=Réinitialiser le Livre de quêtes

--- a/fr_FR/config/txloader/load/BetterQuesting[cb4bq]/lang/fr_FR.lang
+++ b/fr_FR/config/txloader/load/BetterQuesting[cb4bq]/lang/fr_FR.lang
@@ -1,4 +1,4 @@
-tile.CB4BQ.DLB.name=Default Load Block
-tile.CB4BQ.DSB.name=Default Save Block
-tile.CB4BQ.HSB.name=Hardcore Switch Block
-tile.CB4BQ.REB.name=Reset Quest Block
+tile.CB4BQ.DLB.name=Bloc de chargement par défaut
+tile.CB4BQ.DSB.name=Bloc de sauvegarde par défaut
+tile.CB4BQ.HSB.name=Bloc de commutation vers difficile
+tile.CB4BQ.REB.name=Réinitialiser le Livre de quêtes

--- a/src/gtnh_translation_compare/cmd/action.py
+++ b/src/gtnh_translation_compare/cmd/action.py
@@ -86,12 +86,18 @@ class Action:
             if raise_when_empty is not None:
                 raise raise_when_empty
 
+        # Dedupe by the local path the file will actually be written to, not the raw
+        # ParaTranz relpath: ParaTranz-side duplicate names (e.g. "Foo (+3)") and casing
+        # differences only collapse to the same path once path_converter has run.
+        for translation_file in translation_files:
+            translation_file.relpath = str(
+                path_converter(translation_file.relpath) if path_converter is not None else translation_file.relpath
+            )
         translation_files = _dedupe_case_insensitive_paths(translation_files)
 
         for translation_file in translation_files:
             base_path = repo_path / subdirectory
-            translation_file_relpath = path_converter(translation_file.relpath) if path_converter is not None else translation_file.relpath
-            translation_filepath = os.path.abspath(os.path.join(base_path, translation_file_relpath))
+            translation_filepath = os.path.abspath(os.path.join(base_path, translation_file.relpath))
             translation_filepaths.append(translation_filepath)
             write_file(translation_filepath, translation_file.content)
 


### PR DESCRIPTION
The case-insensitive dedupe added in #94 compared raw ParaTranz relpaths, but ParaTranz suffixes duplicate uploads with "(+N)" and path_converter only strips that (and folds casing) afterwards, so two paths that collide once converted still looked different at dedupe time.

Moving the dedupe after path conversion fixes that, and restores the es_ES/fr_FR translations that had drifted back into the CB4BQ duplicate this caused.