### PR TITLE
Key markdown tooltips by their en_US path

### DIFF
--- a/src/gtnh_translation_compare/filetypes/filetype_markdown_tooltip.py
+++ b/src/gtnh_translation_compare/filetypes/filetype_markdown_tooltip.py
@@ -48,7 +48,9 @@ class FiletypeMarkdownTooltip(Filetype):
     def _get_properties(self, content: str) -> Dict[str, Property]:
         if content == "":
             return {}
-        key = f"md-tooltip|{self._relpath}"
+        # The key must be language-independent: ParaTranz stores it built from the en_US path, so a
+        # translated file has to produce the same key for its content to be matched against it.
+        key = f"md-tooltip|{self.get_en_us_relpath()}"
         return {key: Property(key=key, value=content, full=content, start=0, end=len(content))}
 
     def get_en_us_relpath(self) -> str:

--- a/tests/filetypes/test_filetype_markdown_tooltip.py
+++ b/tests/filetypes/test_filetype_markdown_tooltip.py
@@ -47,14 +47,14 @@ def test__get_properties(
     en_us_filetype_markdown_tooltip: FiletypeMarkdownTooltip,
     ru_ru_filetype_markdown_tooltip: FiletypeMarkdownTooltip,
 ) -> None:
-    # The whole file is a single translation unit, keyed by its own relpath.
+    # The whole file is a single translation unit, keyed by its en_US relpath so that a translated
+    # file produces the same key as the English one it belongs to.
     key = f"md-tooltip|{EN_US_RELPATH}"
     assert en_us_filetype_markdown_tooltip.properties == {
         key: Property(key, EN_US_CONTENT, EN_US_CONTENT, 0, len(EN_US_CONTENT)),
     }
-    ru_key = f"md-tooltip|{RU_RU_RELPATH}"
     assert ru_ru_filetype_markdown_tooltip.properties == {
-        ru_key: Property(ru_key, RU_RU_CONTENT, RU_RU_CONTENT, 0, len(RU_RU_CONTENT)),
+        key: Property(key, RU_RU_CONTENT, RU_RU_CONTENT, 0, len(RU_RU_CONTENT)),
     }
 
 


### PR DESCRIPTION
A markdown tooltip is keyed by its own relpath, so the same tooltip read from a translated file produced a different key than the one ParaTranz stores, which is built from the en_US path. upload-jar-translations looked every jar tooltip up by the ParaTranz key, never found it, and silently uploaded nothing for markdown tooltips.

Keying by the en_US path makes the key language-independent. English files are unaffected, so keys already on ParaTranz stay valid.

Spotted on space-research-module.md: GT5-Unofficial ships a Russian version in the jar, while the string sits untranslated on ParaTranz under key md-tooltip|resources/GregTech[gregtech]/lang/en_US/tooltip/space-research-module.md.