### PR TITLE
Rename pluto Ice  blocks (#26321)

### DIFF
--- a/daily-history/resources/GalaxySpace[galaxyspace]/lang/en_US.lang
+++ b/daily-history/resources/GalaxySpace[galaxyspace]/lang/en_US.lang
@@ -208,8 +208,8 @@ tile.CeresDungTop.name=Ceres Dungeon Top
 
 tile.PlutoBlocks.name=Pluto Block
 tile.PlutoGrunt.name=Pluto Surface Ice
-tile.PlutoGrunt2.name=Pluto Surface Ice
-tile.PlutoGrunt3.name=Pluto Surface Ice
+tile.PlutoGrunt2.name=Pluto Nitrogen Ice
+tile.PlutoGrunt3.name=Pluto Tholin Ice
 tile.PlutoGrunt4.name=Pluto Surface Ice
 tile.PlutoSubGrunt.name=Pluto Subsurface Ice
 tile.PlutoStone.name=Pluto Stone


### PR DESCRIPTION
## Summary
<!-- Briefly describe what this PR changes and why. -->

Closes (#26321)

This pr renames 2 pluto ice blocks to pluto methane ice and pluto tholin ice bc. that are more accurate names.

## Checklist
- [x] I have tested this PR in DevEnv
- [x] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
