### PR TITLE
Sync GuideNH guide pages from the bundled guide pack

### DIFF
--- a/src/gtnh_translation_compare/cmd/action.py
+++ b/src/gtnh_translation_compare/cmd/action.py
@@ -301,12 +301,12 @@ class Action:
             relpath = get_relpath(lang_file.get_en_us_relpath())
             write_file(os.path.abspath(relpath), lang_file.content)
 
-        # Guide pages ship in the bundled guide pack rather than in a mod jar. Only en_US is
-        # tracked: the pack also carries translated locale folders, and uploading those would
-        # send finished translations to ParaTranz as source text.
-        for guide_page in modpack.guide_pack_pages(Language.en_US):
-            relpath = get_relpath(guide_page.get_en_us_relpath())
-            write_file(os.path.abspath(relpath), guide_page.content)
+        # Guide pages and the Ponder labels next to them ship in the bundled guide pack rather
+        # than in a mod jar. Only en_US is tracked: the pack also carries translated locales, and
+        # uploading those would send finished translations to ParaTranz as source text.
+        for guide_file in modpack.guide_pack_files(Language.en_US):
+            relpath = get_relpath(guide_file.get_en_us_relpath())
+            write_file(os.path.abspath(relpath), guide_file.content)
 
         self._update_gt_lang(base_path, gt_lang_path)
 

--- a/src/gtnh_translation_compare/cmd/action.py
+++ b/src/gtnh_translation_compare/cmd/action.py
@@ -445,7 +445,7 @@ class Action:
         for file_path in glob.glob(f'./{base_path}/resources/*/guidenh/_en_us/**/*.md', recursive=True):
             with open(file_path, 'r', encoding='UTF-8') as f:
                 content = f.read()
-            lang_files.append(FiletypeGuideNhPage(os.path.relpath(file_path, base_path).replace(os.sep, "/"), content))
+            lang_files.append(FiletypeGuideNhPage(os.path.relpath(file_path, base_path), content))
 
         # concurrency number
         sem = asyncio.Semaphore(10)

--- a/src/gtnh_translation_compare/cmd/action.py
+++ b/src/gtnh_translation_compare/cmd/action.py
@@ -398,6 +398,11 @@ class Action:
             if 'resources' not in file_path:
                 logger.warning(f'Suspecious file detected in changed files: {file_path}')
                 continue
+            # git diff lists deletions too, and a page dropped from the guide pack has nothing
+            # left to upload. Skip it instead of failing the whole sync.
+            if not (base_path / file_path).is_file():
+                logger.info(f'Skipping deleted file: {file_path}')
+                continue
             with open(base_path / file_path, 'r', encoding='UTF-8') as f:
                 content = f.read()
             lang_files.append(_make_lang_or_markdown_filetype(file_path, content))

--- a/src/gtnh_translation_compare/cmd/action.py
+++ b/src/gtnh_translation_compare/cmd/action.py
@@ -18,8 +18,11 @@ from gtnh_translation_compare.filetypes import (
     FiletypeLang,
     Language,
     FiletypeGTLang,
+    FiletypeGuideNhPage,
     FiletypeMarkdownTooltip,
     Filetype,
+    is_guidenh_page_path,
+    is_guidenh_page_paratranz_file,
     is_markdown_tooltip_path,
     is_markdown_tooltip_paratranz_file,
 )
@@ -46,6 +49,8 @@ def _download_from_gtnh(relpath: str) -> str:
 def _make_lang_or_markdown_filetype(relpath: str, content: str) -> Filetype:
     if is_markdown_tooltip_path(relpath):
         return FiletypeMarkdownTooltip(relpath, content)
+    if is_guidenh_page_path(relpath):
+        return FiletypeGuideNhPage(relpath, content)
     return FiletypeLang(relpath, content)
 
 
@@ -136,6 +141,7 @@ class Action:
         files_to_commit.extend(await self._paratranz_to_quest_book(repo_path, subdirectory))
         files_to_commit.extend(await self._paratranz_to_lang(repo_path, subdirectory))
         files_to_commit.extend(await self._paratranz_to_markdown_tooltip(repo_path, subdirectory))
+        files_to_commit.extend(await self._paratranz_to_guidenh_page(repo_path, subdirectory))
         files_to_commit.extend(await self._paratranz_to_gt_lang(repo_path, subdirectory))
 
         git_commit(
@@ -196,6 +202,21 @@ class Action:
                 repo_path,
                 subdirectory,
                 _markdown_tooltip_to_txloader_path,
+        )
+
+    # GuideNH pages
+    async def _paratranz_to_guidenh_page(
+        self,
+        repo_path: Path,
+        subdirectory: Path,
+    ) -> list[str]:
+        return await self.__paratranz_to_translation(
+                is_guidenh_page_paratranz_file,
+                None,
+                None,
+                repo_path,
+                subdirectory,
+                _guidenh_page_to_txloader_path,
         )
 
     # Gt Lang
@@ -279,6 +300,13 @@ class Action:
         for lang_file in modpack.lang_files(Language.en_US):
             relpath = get_relpath(lang_file.get_en_us_relpath())
             write_file(os.path.abspath(relpath), lang_file.content)
+
+        # Guide pages ship in the bundled guide pack rather than in a mod jar. Only en_US is
+        # tracked: the pack also carries translated locale folders, and uploading those would
+        # send finished translations to ParaTranz as source text.
+        for guide_page in modpack.guide_pack_pages(Language.en_US):
+            relpath = get_relpath(guide_page.get_en_us_relpath())
+            write_file(os.path.abspath(relpath), guide_page.content)
 
         self._update_gt_lang(base_path, gt_lang_path)
 
@@ -405,7 +433,7 @@ class Action:
         await self._pack_lang_file_to_paratranz(base_path, settings.CUSTOM_TOOLTIPS_LANG_EN_US_REL_PATH)
         await self._pack_lang_file_to_paratranz(base_path, settings.OVERRIDE_NAMES_LANG_EN_US_REL_PATH)
 
-        lang_files = []
+        lang_files: list[Filetype] = []
         for file_path in glob.glob(f'./{base_path}/resources/*/lang/en_US.lang'):
             with open(file_path, 'r', encoding='UTF-8') as f:
                 content = f.read()
@@ -414,6 +442,10 @@ class Action:
             with open(file_path, 'r', encoding='UTF-8') as f:
                 content = f.read()
             lang_files.append(FiletypeMarkdownTooltip(os.path.relpath(file_path, base_path), content))
+        for file_path in glob.glob(f'./{base_path}/resources/*/guidenh/_en_us/**/*.md', recursive=True):
+            with open(file_path, 'r', encoding='UTF-8') as f:
+                content = f.read()
+            lang_files.append(FiletypeGuideNhPage(os.path.relpath(file_path, base_path).replace(os.sep, "/"), content))
 
         # concurrency number
         sem = asyncio.Semaphore(10)
@@ -627,20 +659,28 @@ MOD_DOMAIN_RE = re.compile(r"\[([^\[\]]+)\]$")
 
 
 def _markdown_tooltip_to_txloader_path(path: str) -> Path:
-    # Markdown tooltips only, never .lang: unlike .lang, a tooltip slug belongs to one mod,
-    # so collapsing "<DisplayName>[<domain>]" to the bare domain here is safe. Don't reuse
-    # this for _resources_to_txloader_path's job - addon mods contribute lines to another
+    return _bracketed_domain_to_txloader_path(path, "markdown tooltip")
+
+
+def _guidenh_page_to_txloader_path(path: str) -> Path:
+    return _bracketed_domain_to_txloader_path(path, "GuideNH page")
+
+
+def _bracketed_domain_to_txloader_path(path: str, kind: str) -> Path:
+    # Markdown tooltips and GuideNH pages only, never .lang: unlike .lang, such a file belongs
+    # to one mod, so collapsing "<DisplayName>[<domain>]" to the bare domain here is safe. Don't
+    # reuse this for _resources_to_txloader_path's job - addon mods contribute lines to another
     # mod's .lang through their own bracketed folder, and collapsing those would drop one
     # contributor's translations whenever two folders share a domain and relative path.
     cfg = Path("config")
     provided = Path(path)
     parts = list(provided.parts)
     if len(parts) < 2 or parts[0] != "resources":
-        logger.warning(f"Unknown path for markdown tooltip {path}")
+        logger.warning(f"Unknown path for {kind} {path}")
         return cfg / "txloader" / "load" / provided
     match = MOD_DOMAIN_RE.search(parts[1])
     if match is None:
-        logger.warning(f"Could not find mod domain in {parts[1]!r} for markdown tooltip {path}")
+        logger.warning(f"Could not find mod domain in {parts[1]!r} for {kind} {path}")
         return cfg / "txloader" / "load" / Path(*parts[1:])
     return cfg / "txloader" / "load" / match.group(1) / Path(*parts[2:])
 

--- a/src/gtnh_translation_compare/filetypes/__init__.py
+++ b/src/gtnh_translation_compare/filetypes/__init__.py
@@ -1,5 +1,10 @@
 from gtnh_translation_compare.filetypes.filetype import Filetype
 from gtnh_translation_compare.filetypes.filetype_gt_lang import FiletypeGTLang
+from gtnh_translation_compare.filetypes.filetype_guidenh_page import (
+    FiletypeGuideNhPage,
+    is_guidenh_page_path,
+    is_guidenh_page_paratranz_file,
+)
 from gtnh_translation_compare.filetypes.filetype_lang import FiletypeLang
 from gtnh_translation_compare.filetypes.filetype_markdown_tooltip import (
     FiletypeMarkdownTooltip,
@@ -12,8 +17,11 @@ from gtnh_translation_compare.filetypes.property import Property
 __all__ = [
     "Filetype",
     "FiletypeGTLang",
+    "FiletypeGuideNhPage",
     "FiletypeLang",
     "FiletypeMarkdownTooltip",
+    "is_guidenh_page_path",
+    "is_guidenh_page_paratranz_file",
     "is_markdown_tooltip_path",
     "is_markdown_tooltip_paratranz_file",
     "Language",

--- a/src/gtnh_translation_compare/filetypes/filetype_guidenh_page.py
+++ b/src/gtnh_translation_compare/filetypes/filetype_guidenh_page.py
@@ -1,0 +1,68 @@
+import re
+from typing import Dict
+
+from gtnh_translation_compare.filetypes.filetype import Filetype
+from gtnh_translation_compare.filetypes.language import Language
+from gtnh_translation_compare.filetypes.property import Property
+
+# Shared between modpack.py's guide pack scanner, the daily-sync workflow's changed-file
+# dispatcher, and the ParaTranz-download filter, so all three agree on what counts as a
+# GuideNH page. Language-agnostic (matches any locale segment) since callers see the file
+# under different locales depending on which side they're on.
+GUIDENH_PAGE_PATH_RE = re.compile(r"/guidenh/_[a-z]{2}_[a-z]{2}/.*\.md$")
+
+
+def is_guidenh_page_path(relpath: str) -> bool:
+    return GUIDENH_PAGE_PATH_RE.search(relpath) is not None
+
+
+def is_guidenh_page_paratranz_file(name: str) -> bool:
+    # ParaTranz always appends ".json" to the original file's relpath.
+    return is_guidenh_page_path(name.removesuffix(".json"))
+
+
+def language_folder(language: Language) -> str:
+    # GuideNH reads locale folders in the underscored lowercase form ("_en_us"), while
+    # Language carries the Minecraft form ("en_US").
+    return f"_{language.value.lower()}"
+
+
+class FiletypeGuideNhPage(Filetype):
+    """
+    A GuideNH guide page (`assets/<namespace>/guidenh/_<locale>/<page>.md`), shipped in the
+    GTNH Guide Pack and loaded from `config/guidenh/DefaultGuide.zip`. Like the GregTech
+    markdown tooltips, there is no key=value structure: the whole file is markdown with YAML
+    frontmatter, addressed by its file path rather than by a key inside it.
+
+    We therefore treat the entire file as a single translatable unit, keyed by its own
+    relpath, which lets translators reflow a full page as one coherent text.
+    """
+
+    def __init__(self, relpath: str, content: str, language: Language = Language.en_US):
+        self._relpath = relpath
+        self._content = content
+        self._language = language
+
+    def _get_relpath(self) -> str:
+        return self._relpath
+
+    def _get_content(self) -> str:
+        return self._content
+
+    def _get_properties(self, content: str) -> Dict[str, Property]:
+        if content == "":
+            return {}
+        # The key must be language-independent: ParaTranz stores it built from the en_US path, so a
+        # translated file has to produce the same key for its content to be matched against it.
+        key = f"guidenh-page|{self.get_en_us_relpath()}"
+        return {key: Property(key=key, value=content, full=content, start=0, end=len(content))}
+
+    def get_en_us_relpath(self) -> str:
+        if self._language == Language.en_US:
+            return self._relpath
+        return self._relpath.replace(language_folder(self._language), language_folder(Language.en_US))
+
+    def get_target_language_relpath(self, target_language: Language) -> str:
+        if self._language == target_language:
+            return self._relpath
+        return self._relpath.replace(language_folder(self._language), language_folder(target_language))

--- a/src/gtnh_translation_compare/modpack/modpack.py
+++ b/src/gtnh_translation_compare/modpack/modpack.py
@@ -4,10 +4,22 @@ from functools import cache
 from os import path
 from typing import Sequence
 
-from gtnh_translation_compare.filetypes import Filetype, FiletypeLang, FiletypeMarkdownTooltip
+from gtnh_translation_compare.filetypes import (
+    Filetype,
+    FiletypeGuideNhPage,
+    FiletypeLang,
+    FiletypeMarkdownTooltip,
+)
+from gtnh_translation_compare.filetypes.filetype_guidenh_page import language_folder
 from gtnh_translation_compare.filetypes.language import Language
 from gtnh_translation_compare.modpack.mod import Mod
 from gtnh_translation_compare.utils.file import ensure_lf
+
+# The GTNH Guide Pack is not a mod jar: the modpack's release workflow downloads the matching
+# guide pack release and bundles it under this path, so the pages ride along with the modpack
+# archive instead of being shipped by any mod.
+GUIDE_PACK_REL_PATH = "config/guidenh/DefaultGuide.zip"
+GUIDE_PACK_NAME = "GTNH Guide Pack"
 
 
 class ModPack:
@@ -38,3 +50,28 @@ class ModPack:
                         FiletypeMarkdownTooltip(f"resources/{mod.mod_name}[{sub_mod_id}]/{filename}", content, language)
                     )
         return lang_files
+
+    @cache
+    def guide_pack_pages(self, language: Language) -> Sequence[Filetype]:
+        guide_pack_path = self.__pack_path / GUIDE_PACK_REL_PATH
+        if not guide_pack_path.is_file():
+            # Older modpack releases predate the bundled guide pack, so its absence is expected.
+            return []
+
+        pages: list[Filetype] = []
+        locale_folder = language_folder(language)
+        with zipfile.ZipFile(guide_pack_path) as guide_pack:
+            for filename in guide_pack.namelist():
+                parts = filename.split("/")
+                # assets/<namespace>/guidenh/_<locale>/<page...>.md (nested pages allowed)
+                if len(parts) < 5:
+                    continue
+                if parts[0] != "assets" or parts[2] != "guidenh" or parts[3] != locale_folder:
+                    continue
+                if not filename.endswith(".md"):
+                    continue
+                with guide_pack.open(filename, mode="r") as page:
+                    content = ensure_lf(page.read().decode("utf-8-sig", errors="ignore"))
+                relpath = "/".join([f"resources/{GUIDE_PACK_NAME}[{parts[1]}]", *parts[2:]])
+                pages.append(FiletypeGuideNhPage(relpath, content, language))
+        return pages

--- a/src/gtnh_translation_compare/modpack/modpack.py
+++ b/src/gtnh_translation_compare/modpack/modpack.py
@@ -52,26 +52,36 @@ class ModPack:
         return lang_files
 
     @cache
-    def guide_pack_pages(self, language: Language) -> Sequence[Filetype]:
+    def guide_pack_files(self, language: Language) -> Sequence[Filetype]:
         guide_pack_path = self.__pack_path / GUIDE_PACK_REL_PATH
         if not guide_pack_path.is_file():
             # Older modpack releases predate the bundled guide pack, so its absence is expected.
             return []
 
-        pages: list[Filetype] = []
+        files: list[Filetype] = []
         locale_folder = language_folder(language)
+        # The pack writes lowercase lang file names, while the rest of the pipeline substitutes
+        # the Minecraft form, so the tracked relpath has to carry "en_US.lang". GuideNH compares
+        # language names case-insensitively, so the renamed file still loads in game.
+        pack_lang_name = f"{language.value.lower()}.lang"
         with zipfile.ZipFile(guide_pack_path) as guide_pack:
             for filename in guide_pack.namelist():
                 parts = filename.split("/")
-                # assets/<namespace>/guidenh/_<locale>/<page...>.md (nested pages allowed)
-                if len(parts) < 5:
+                if len(parts) < 4 or parts[0] != "assets":
                     continue
-                if parts[0] != "assets" or parts[2] != "guidenh" or parts[3] != locale_folder:
+                relpath_prefix = f"resources/{GUIDE_PACK_NAME}[{parts[1]}]"
+
+                # assets/<namespace>/lang/<locale>.lang, holding the Ponder labels of the pack
+                if len(parts) == 4 and parts[2] == "lang" and parts[3] == pack_lang_name:
+                    content = ensure_lf(guide_pack.read(filename).decode("utf-8-sig", errors="ignore"))
+                    files.append(FiletypeLang(f"{relpath_prefix}/lang/{language.value}.lang", content, language))
+                    continue
+
+                # assets/<namespace>/guidenh/_<locale>/<page...>.md (nested pages allowed)
+                if len(parts) < 5 or parts[2] != "guidenh" or parts[3] != locale_folder:
                     continue
                 if not filename.endswith(".md"):
                     continue
-                with guide_pack.open(filename, mode="r") as page:
-                    content = ensure_lf(page.read().decode("utf-8-sig", errors="ignore"))
-                relpath = "/".join([f"resources/{GUIDE_PACK_NAME}[{parts[1]}]", *parts[2:]])
-                pages.append(FiletypeGuideNhPage(relpath, content, language))
-        return pages
+                content = ensure_lf(guide_pack.read(filename).decode("utf-8-sig", errors="ignore"))
+                files.append(FiletypeGuideNhPage("/".join([relpath_prefix, *parts[2:]]), content, language))
+        return files

--- a/tests/cmd/test_action.py
+++ b/tests/cmd/test_action.py
@@ -1,0 +1,28 @@
+from pathlib import Path
+
+from gtnh_translation_compare.cmd.action import _guidenh_page_to_txloader_path, _make_lang_or_markdown_filetype
+from gtnh_translation_compare.filetypes import FiletypeGuideNhPage, FiletypeLang, FiletypeMarkdownTooltip
+
+GUIDE_PAGE_RELPATH = "resources/GTNH Guide Pack[gregtech]/guidenh/_ru_ru/items_blocks/singleblock_machines.md"
+
+
+def test_guidenh_page_to_txloader_path() -> None:
+    # GuideNH reads guide pages from the resource domain, so the bracketed display name collapses
+    # to the bare domain, and the locale folder rides along untouched.
+    assert _guidenh_page_to_txloader_path(GUIDE_PAGE_RELPATH) == Path(
+        "config/txloader/load/gregtech/guidenh/_ru_ru/items_blocks/singleblock_machines.md"
+    )
+
+
+def test_make_lang_or_markdown_filetype_dispatch() -> None:
+    # The daily sync feeds changed files through this dispatcher, so a guide page that falls
+    # through to FiletypeLang would upload as a broken key=value parse.
+    assert isinstance(_make_lang_or_markdown_filetype(GUIDE_PAGE_RELPATH, "# Machines"), FiletypeGuideNhPage)
+    assert isinstance(
+        _make_lang_or_markdown_filetype("resources/GregTech[gregtech]/lang/en_US/tooltip/bec-ionode.md", "Teleports"),
+        FiletypeMarkdownTooltip,
+    )
+    assert isinstance(
+        _make_lang_or_markdown_filetype("resources/GregTech[gregtech]/lang/en_US.lang", "item.foo.name=Foo"),
+        FiletypeLang,
+    )

--- a/tests/filetypes/test_filetype_guidenh_page.py
+++ b/tests/filetypes/test_filetype_guidenh_page.py
@@ -1,0 +1,94 @@
+from gtnh_translation_compare.filetypes import FiletypeGuideNhPage, Language, Property, is_guidenh_page_path
+import pytest
+
+EN_US_RELPATH = "resources/GTNH Guide Pack[gregtech]/guidenh/_en_us/items_blocks/singleblock_machines.md"
+EN_US_CONTENT = "\n".join(
+    [
+        "---",
+        "navigation:",
+        "  title: Singleblock Machines",
+        "---",
+        "",
+        "Singleblock machines consist of only one block.",
+    ]
+)
+RU_RU_RELPATH = "resources/GTNH Guide Pack[gregtech]/guidenh/_ru_ru/items_blocks/singleblock_machines.md"
+RU_RU_CONTENT = "\n".join(
+    [
+        "---",
+        "navigation:",
+        "  title: Одноблочные машины",
+        "---",
+        "",
+        "Одноблочные машины состоят из одного блока.",
+    ]
+)
+
+
+@pytest.fixture(scope="module")
+def en_us_filetype_guidenh_page() -> FiletypeGuideNhPage:
+    return FiletypeGuideNhPage(EN_US_RELPATH, EN_US_CONTENT)
+
+
+@pytest.fixture(scope="module")
+def ru_ru_filetype_guidenh_page() -> FiletypeGuideNhPage:
+    return FiletypeGuideNhPage(RU_RU_RELPATH, RU_RU_CONTENT, Language.ru_RU)
+
+
+def test__get_relpath(
+    en_us_filetype_guidenh_page: FiletypeGuideNhPage,
+    ru_ru_filetype_guidenh_page: FiletypeGuideNhPage,
+) -> None:
+    assert en_us_filetype_guidenh_page.relpath == EN_US_RELPATH
+    assert ru_ru_filetype_guidenh_page.relpath == RU_RU_RELPATH
+
+
+def test__get_content(
+    en_us_filetype_guidenh_page: FiletypeGuideNhPage,
+    ru_ru_filetype_guidenh_page: FiletypeGuideNhPage,
+) -> None:
+    assert en_us_filetype_guidenh_page.content == EN_US_CONTENT
+    assert ru_ru_filetype_guidenh_page.content == RU_RU_CONTENT
+
+
+def test__get_properties(
+    en_us_filetype_guidenh_page: FiletypeGuideNhPage,
+    ru_ru_filetype_guidenh_page: FiletypeGuideNhPage,
+) -> None:
+    # The whole page is a single translation unit, keyed by its en_US relpath so that a translated
+    # page produces the same key as the English one it belongs to.
+    key = f"guidenh-page|{EN_US_RELPATH}"
+    assert en_us_filetype_guidenh_page.properties == {
+        key: Property(key, EN_US_CONTENT, EN_US_CONTENT, 0, len(EN_US_CONTENT)),
+    }
+    assert ru_ru_filetype_guidenh_page.properties == {
+        key: Property(key, RU_RU_CONTENT, RU_RU_CONTENT, 0, len(RU_RU_CONTENT)),
+    }
+
+
+def test__get_properties_empty_file() -> None:
+    assert FiletypeGuideNhPage(EN_US_RELPATH, "").properties == {}
+
+
+def test_get_en_us_relpath(
+    en_us_filetype_guidenh_page: FiletypeGuideNhPage,
+    ru_ru_filetype_guidenh_page: FiletypeGuideNhPage,
+) -> None:
+    assert en_us_filetype_guidenh_page.get_en_us_relpath() == EN_US_RELPATH
+    assert ru_ru_filetype_guidenh_page.get_en_us_relpath() == EN_US_RELPATH
+
+
+def test_get_target_relpath(
+    en_us_filetype_guidenh_page: FiletypeGuideNhPage,
+    ru_ru_filetype_guidenh_page: FiletypeGuideNhPage,
+) -> None:
+    # GuideNH names its locale folders in lowercase, so the Language value cannot be substituted as is.
+    assert en_us_filetype_guidenh_page.get_target_language_relpath(Language.ru_RU) == RU_RU_RELPATH
+    assert ru_ru_filetype_guidenh_page.get_target_language_relpath(Language.en_US) == EN_US_RELPATH
+
+
+def test_is_guidenh_page_path() -> None:
+    assert is_guidenh_page_path(EN_US_RELPATH)
+    assert is_guidenh_page_path(RU_RU_RELPATH)
+    assert not is_guidenh_page_path("resources/GregTech[gregtech]/lang/en_US.lang")
+    assert not is_guidenh_page_path("resources/GTNH Guide Pack[gregtech]/guidenh/_en_us/index.md.json")

--- a/tests/modpack/test_modpack.py
+++ b/tests/modpack/test_modpack.py
@@ -8,6 +8,7 @@ from gtnh_translation_compare.modpack.modpack import ModPack
 MOD_NAME = "GregTech"
 MOD_ID = "gregtech"
 TOOLTIP_SLUG = "tooltip/space-research-module.md"
+GUIDE_PAGE_SLUG = "items_blocks/singleblock_machines.md"
 
 
 def _make_modpack(tmp_path: pathlib.Path) -> ModPack:
@@ -36,3 +37,32 @@ def test_markdown_tooltip_key_is_language_independent(tmp_path: pathlib.Path) ->
         for language in (Language.en_US, Language.ru_RU)
     }
     assert keys[Language.en_US] == keys[Language.ru_RU]
+
+
+def _add_guide_pack(pack_path: pathlib.Path) -> None:
+    guide_pack_path = pack_path / "config" / "guidenh" / "DefaultGuide.zip"
+    guide_pack_path.parent.mkdir(parents=True)
+    with zipfile.ZipFile(guide_pack_path, "w") as guide_pack:
+        guide_pack.writestr(f"assets/{MOD_ID}/guidenh/_en_us/{GUIDE_PAGE_SLUG}", "# Machines")
+        guide_pack.writestr(f"assets/{MOD_ID}/guidenh/_zh_cn/{GUIDE_PAGE_SLUG}", "# 机器")
+        guide_pack.writestr(f"assets/{MOD_ID}/guidenh/_en_us/assets/images/machine.png", "not markdown")
+        guide_pack.writestr("pack.mcmeta", "{}")
+
+
+def test_guide_pack_pages_are_read_per_language(tmp_path: pathlib.Path) -> None:
+    modpack = _make_modpack(tmp_path)
+    _add_guide_pack(tmp_path)
+
+    en_us_pages = modpack.guide_pack_pages(Language.en_US)
+    zh_cn_pages = modpack.guide_pack_pages(Language.zh_CN)
+
+    # Non-markdown assets and other locale folders stay out of the requested language.
+    assert [page.relpath for page in en_us_pages] == [
+        f"resources/GTNH Guide Pack[{MOD_ID}]/guidenh/_en_us/{GUIDE_PAGE_SLUG}"
+    ]
+    assert [page.get_en_us_relpath() for page in zh_cn_pages] == [page.relpath for page in en_us_pages]
+
+
+def test_guide_pack_pages_without_guide_pack(tmp_path: pathlib.Path) -> None:
+    # Modpack releases older than the bundled guide pack still have to sync.
+    assert _make_modpack(tmp_path).guide_pack_pages(Language.en_US) == []

--- a/tests/modpack/test_modpack.py
+++ b/tests/modpack/test_modpack.py
@@ -46,23 +46,27 @@ def _add_guide_pack(pack_path: pathlib.Path) -> None:
         guide_pack.writestr(f"assets/{MOD_ID}/guidenh/_en_us/{GUIDE_PAGE_SLUG}", "# Machines")
         guide_pack.writestr(f"assets/{MOD_ID}/guidenh/_zh_cn/{GUIDE_PAGE_SLUG}", "# 机器")
         guide_pack.writestr(f"assets/{MOD_ID}/guidenh/_en_us/assets/images/machine.png", "not markdown")
+        guide_pack.writestr(f"assets/{MOD_ID}/lang/en_us.lang", "gregtech.ebf.ponder.label.overview=Overview\n")
+        guide_pack.writestr(f"assets/{MOD_ID}/lang/zh_cn.lang", "gregtech.ebf.ponder.label.overview=概览\n")
         guide_pack.writestr("pack.mcmeta", "{}")
 
 
-def test_guide_pack_pages_are_read_per_language(tmp_path: pathlib.Path) -> None:
+def test_guide_pack_files_are_read_per_language(tmp_path: pathlib.Path) -> None:
     modpack = _make_modpack(tmp_path)
     _add_guide_pack(tmp_path)
 
-    en_us_pages = modpack.guide_pack_pages(Language.en_US)
-    zh_cn_pages = modpack.guide_pack_pages(Language.zh_CN)
+    en_us_files = modpack.guide_pack_files(Language.en_US)
+    zh_cn_files = modpack.guide_pack_files(Language.zh_CN)
 
-    # Non-markdown assets and other locale folders stay out of the requested language.
-    assert [page.relpath for page in en_us_pages] == [
-        f"resources/GTNH Guide Pack[{MOD_ID}]/guidenh/_en_us/{GUIDE_PAGE_SLUG}"
+    # Non-markdown assets and other locale folders stay out of the requested language. The pack
+    # names its lang files in lowercase, but the tracked relpath carries the Minecraft form.
+    assert sorted(file.relpath for file in en_us_files) == [
+        f"resources/GTNH Guide Pack[{MOD_ID}]/guidenh/_en_us/{GUIDE_PAGE_SLUG}",
+        f"resources/GTNH Guide Pack[{MOD_ID}]/lang/en_US.lang",
     ]
-    assert [page.get_en_us_relpath() for page in zh_cn_pages] == [page.relpath for page in en_us_pages]
+    assert sorted(file.get_en_us_relpath() for file in zh_cn_files) == sorted(file.relpath for file in en_us_files)
 
 
-def test_guide_pack_pages_without_guide_pack(tmp_path: pathlib.Path) -> None:
+def test_guide_pack_files_without_guide_pack(tmp_path: pathlib.Path) -> None:
     # Modpack releases older than the bundled guide pack still have to sync.
-    assert _make_modpack(tmp_path).guide_pack_pages(Language.en_US) == []
+    assert _make_modpack(tmp_path).guide_pack_files(Language.en_US) == []


### PR DESCRIPTION
## Summary
The modpack release workflow downloads the matching GTNH-Guide-Pack release and bundles it as `config/guidenh/DefaultGuide.zip`, so the daily archive carries the English guide pages. This picks them out of that zip and syncs them like the GregTech markdown tooltips: one page is one translation unit, keyed by its `en_US` path.

Translations come back in the language release under `config/txloader/load/<domain>/guidenh/_<locale>/`. TX Loader loads after DefaultGuide, so the translated page wins.

Only `_en_us` goes up. The pack ships `_zh_cn` as well, and uploading that would send finished translations to ParaTranz as source text.

## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
