### PR TITLE
Survive ParaTranz rate limits on bulk uploads

### DIFF
--- a/src/gtnh_translation_compare/cmd/action.py
+++ b/src/gtnh_translation_compare/cmd/action.py
@@ -407,8 +407,8 @@ class Action:
                 content = f.read()
             lang_files.append(_make_lang_or_markdown_filetype(file_path, content))
 
-        # concurrency number
-        sem = asyncio.Semaphore(10)
+        # concurrency number, kept low because every language job shares one ParaTranz token
+        sem = asyncio.Semaphore(4)
 
         async def upload_file(_sem: asyncio.Semaphore, lang_file: Filetype) -> None:
             async with _sem:
@@ -452,8 +452,8 @@ class Action:
                 content = f.read()
             lang_files.append(FiletypeGuideNhPage(os.path.relpath(file_path, base_path), content))
 
-        # concurrency number
-        sem = asyncio.Semaphore(10)
+        # concurrency number, kept low because every language job shares one ParaTranz token
+        sem = asyncio.Semaphore(4)
 
         async def upload_file(_sem: asyncio.Semaphore, lang_file: Filetype) -> None:
             async with _sem:

--- a/src/gtnh_translation_compare/paratranz/client_wrapper.py
+++ b/src/gtnh_translation_compare/paratranz/client_wrapper.py
@@ -14,6 +14,9 @@ from gtnh_translation_compare.paratranz.types import File, StringItem, StringPag
 
 def retry_after_429() -> Callable[[WrappedFn], WrappedFn]:
     wait_seconds = 60
+    # ParaTranz counts requests per token and all languages sync with the same one, so a run that
+    # creates hundreds of files at once queues across several rate limit windows before it lands.
+    max_attempts = 6
 
     def is_http_429_error(exception: BaseException) -> bool:
         return isinstance(exception, HTTPStatusError) and exception.response.status_code == 429
@@ -22,13 +25,13 @@ def retry_after_429() -> Callable[[WrappedFn], WrappedFn]:
         logger.warning(
             f"received a 429 response, "
             f"waiting {wait_seconds} seconds before retrying "
-            f"for the { {2: '2nd', 3: '3rd'}.get(retry_state.attempt_number + 1)} time"
+            f"({retry_state.attempt_number + 1} of {max_attempts})"
         )
 
     return retry(
         retry=retry_if_exception(is_http_429_error),
         wait=wait_fixed(wait_seconds),
-        stop=stop_after_attempt(3),
+        stop=stop_after_attempt(max_attempts),
         before_sleep=before_sleep,
     )
 


### PR DESCRIPTION
## Summary
The first sync carrying the guide pack creates 302 files per language, and all nine language jobs use the same ParaTranz token, so the uploads spent every rate limit window in 429s and ran out of the three retries. Run #450 died that way in each language.

Wait through more windows before giving up, and keep fewer requests in flight per job. A regular day uploads a handful of files and reaches neither limit.


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [ ] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
