### PR TITLE
Skip source files with no strings

### DIFF
--- a/src/gtnh_translation_compare/paratranz/client_wrapper.py
+++ b/src/gtnh_translation_compare/paratranz/client_wrapper.py
@@ -143,6 +143,14 @@ class ClientWrapper:
         return strings
 
     async def upload_file(self, paratranz_file: ParatranzFile) -> None:
+        if not paratranz_file.string_items:
+            # A source file with nothing to translate, such as an empty guide page, makes
+            # ParaTranz answer the create without a file object, and the sync used to die on
+            # that response and drop every file queued behind it.
+            print(f"::warning::skipping source file with no strings: {paratranz_file.file_name}")
+            logger.warning("skipping source file with no strings: {}", paratranz_file.file_name)
+            return
+
         file_id = await self._find_file_id_by_file(paratranz_file.file_name)
 
         if file_id is None:

--- a/tests/paratranz/test_client_wrapper.py
+++ b/tests/paratranz/test_client_wrapper.py
@@ -1,0 +1,32 @@
+import asyncio
+import pathlib
+
+import httpx
+
+from gtnh_translation_compare.paratranz.client_wrapper import ClientWrapper
+from gtnh_translation_compare.paratranz.types import FileExtra, ParatranzFile
+
+
+def _refusing_client() -> httpx.AsyncClient:
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise AssertionError(f"unexpected request: {request.method} {request.url}")
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(handler), base_url="https://paratranz.cn/api")
+
+
+def test_upload_file_skips_a_file_without_strings(tmp_path: pathlib.Path) -> None:
+    # The guide pack shipped an empty page once, and ParaTranz answers a create for a file with
+    # no strings without the file object, which used to end the sync for every file behind it.
+    paratranz_file = ParatranzFile(
+        file_name="resources/GTNH Guide Pack[gregtech]/guidenh/_ru_ru/misc/misc-index.md.json",
+        file_extra=FileExtra(
+            original="",
+            properties={},
+            en_us_relpath="resources/GTNH Guide Pack[gregtech]/guidenh/_en_us/misc/misc-index.md",
+            target_relpath="resources/GTNH Guide Pack[gregtech]/guidenh/_ru_ru/misc/misc-index.md",
+        ),
+        string_items=[],
+    )
+    client = ClientWrapper(client=_refusing_client(), project_id=1, cache_dir=str(tmp_path))
+
+    asyncio.run(client.upload_file(paratranz_file))


### PR DESCRIPTION
## Summary
The guide pack ships `gregtech/guidenh/_en_us/misc/misc-index.md` as an empty file. ParaTranz answers a create for a file with no strings without the file object, so `_create_file` died on `KeyError: 'file'` and took the whole language job with it, dropping every file queued behind it. Runs #450 and #451 lost the rest of the gregtech pages that way in all nine languages.

Skip such a file with a warning instead. The empty page itself is being fixed in the guide pack, but one broken source file should not stop the sync for everyone.


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [ ] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
