### PR TITLE
Add a report of orphaned ParaTranz files

### DIFF
--- a/.github/workflows/report-paratranz-orphans.yml
+++ b/.github/workflows/report-paratranz-orphans.yml
@@ -1,0 +1,47 @@
+name: Report orphaned ParaTranz files
+
+on:
+  workflow_dispatch:
+    inputs:
+      target_lang:
+        description: "Target language to run"
+        required: true
+        type: choice
+        options:
+          - zh_CN
+          - ja_JP
+          - ko_KR
+          - pt_BR
+          - fr_FR
+          - es_ES
+          - tr_TR
+          - de_DE
+          - pl_PL
+          - ru_RU
+
+env:
+  PARATRANZ_TOKEN: ${{ secrets.PARATRANZ_TOKEN }}
+
+jobs:
+  report-paratranz-orphans:
+    name: ${{ inputs.target_lang }} Report orphaned ParaTranz files
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: master
+      - name: Get project ID
+        id: get-project-id
+        uses: ./.github/actions/get-project-id
+        with:
+          target_lang: ${{ inputs.target_lang }}
+      - name: Ensure Dependencies
+        uses: ./.github/actions/ensure-dependencies
+
+      - name: Report orphaned files
+        run: >-
+          poetry run python main.py action report-paratranz-orphans
+          --subdirectory='daily-history'
+        env:
+          PARATRANZ_PROJECT_ID: ${{ steps.get-project-id.outputs.project_id }}
+          TARGET_LANG: ${{ inputs.target_lang }}

--- a/src/gtnh_translation_compare/cmd/action.py
+++ b/src/gtnh_translation_compare/cmd/action.py
@@ -54,6 +54,11 @@ def _make_lang_or_markdown_filetype(relpath: str, content: str) -> Filetype:
     return FiletypeLang(relpath, content)
 
 
+def _paratranz_name_key(name: str) -> str:
+    """Name reduced to what a rename usually keeps: case, dashes and underscores drop out."""
+    return name.lower().replace('-', '').replace('_', '')
+
+
 def _github_actions_escape(message: str) -> str:
     return message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
 
@@ -510,6 +515,65 @@ class Action:
             subdirectory: str = ".",
     ) -> None:
         asyncio.run(self._sync_all_to_paratranz(Path(repo_path), Path(subdirectory)))
+
+    ############################################################################
+    # Orphaned ParaTranz files
+    ############################################################################
+
+    def _expected_paratranz_names(self, base_path: Path) -> set[str]:
+        """Names ParaTranz would hold if it mirrored the current daily history."""
+        source_files: list[Filetype] = [
+            self._read_pack_lang_file(base_path, settings.DEFAULT_QUESTS_LANG_EN_US_REL_PATH),
+            self._read_pack_lang_file(base_path, settings.CUSTOM_TOOLTIPS_LANG_EN_US_REL_PATH),
+            self._read_pack_lang_file(base_path, settings.OVERRIDE_NAMES_LANG_EN_US_REL_PATH),
+        ]
+        for pattern, filetype in (
+            ('resources/*/lang/en_US.lang', FiletypeLang),
+            ('resources/*/lang/en_US/tooltip/**/*.md', FiletypeMarkdownTooltip),
+            ('resources/*/guidenh/_en_us/**/*.md', FiletypeGuideNhPage),
+        ):
+            for file_path in glob.glob(f"./{base_path}/{pattern}", recursive=True):
+                relpath = os.path.relpath(file_path, base_path).replace(os.sep, "/")
+                source_files.append(filetype(relpath, ""))
+
+        names = {f.get_target_language_relpath(settings.TARGET_LANG) + ".json" for f in source_files}
+        names.add(settings.GT_LANG_TARGET_REL_PATH + ".json")
+        return names
+
+    async def _report_paratranz_orphans(
+            self,
+            repo_path: Path,
+            subdirectory: Path,
+    ) -> None:
+        base_path: Path = repo_path / subdirectory
+        expected = self._expected_paratranz_names(base_path)
+        # Mods and the guide pack rename folders and files, and the rename leaves the previous
+        # ParaTranz file behind with its translations. Match a leftover to its successor by the
+        # part of the name that renames tend to keep.
+        expected_by_key: Dict[str, str] = {_paratranz_name_key(name): name for name in expected}
+
+        orphans = [f for f in await self.client.get_all_files() if f.name not in expected]
+        if not orphans:
+            logger.info("No orphaned files: every ParaTranz file matches the current daily history")
+            return
+
+        logger.info("Orphaned ParaTranz files: {}", len(orphans))
+        for orphan in sorted(orphans, key=lambda f: f.name):
+            successor = expected_by_key.get(_paratranz_name_key(orphan.name))
+            translated = [s for s in await self.client.get_strings(orphan.id) if s.translation]
+            logger.info(
+                "orphan={} translated_strings={} successor={}",
+                orphan.name,
+                len(translated),
+                successor or "<none>",
+            )
+
+    def report_paratranz_orphans(
+            self,
+            repo_path: str = ".",
+            subdirectory: str = ".",
+    ) -> None:
+        asyncio.run(self._report_paratranz_orphans(Path(repo_path), Path(subdirectory)))
 
     ############################################################################
     # Import translations from jars

--- a/src/gtnh_translation_compare/cmd/action.py
+++ b/src/gtnh_translation_compare/cmd/action.py
@@ -37,6 +37,10 @@ ParatranzFilenameFilter: TypeAlias = Callable[[str], bool]
 ParatranzToLocalPathConverter: TypeAlias = Callable[[str], Path]
 AfterToTranslationFileCallback: TypeAlias = Callable[[TranslationFile], None]
 
+# ParaTranz used to append "(+3)" and the like to a duplicate name, and those names still sit in
+# the projects even though nothing produces them any more.
+DUPLICATE_NAME_SUFFIX_RE = re.compile(r"\(\+\d+\)")
+
 
 def _download_from_gtnh(relpath: str) -> str:
     url = f"https://raw.githubusercontent.com/{settings.GTNH_REPO}/master/{relpath}"
@@ -55,8 +59,9 @@ def _make_lang_or_markdown_filetype(relpath: str, content: str) -> Filetype:
 
 
 def _paratranz_name_key(name: str) -> str:
-    """Name reduced to what a rename usually keeps: case, dashes and underscores drop out."""
-    return name.lower().replace('-', '').replace('_', '')
+    """Name reduced to what a rename usually keeps: case, dashes, underscores and the duplicate
+    suffix ParaTranz once appended (Angelica(+3) became Angelica) all drop out."""
+    return DUPLICATE_NAME_SUFFIX_RE.sub("", name).lower().replace("-", "").replace("_", "")
 
 
 def _github_actions_escape(message: str) -> str:
@@ -749,7 +754,7 @@ def _resources_to_txloader_path_internal(path: str) -> tuple[bool, Path]:
     elif provided.parts and provided.parts[0] == "resources":
         parts = list(provided.parts)
         for i in range(len(parts)):
-            result = re.sub(r"\(\+\d+\)", "", parts[i])
+            result = DUPLICATE_NAME_SUFFIX_RE.sub("", parts[i])
             if result != parts[i]:
                 isCanonical = False
                 logger.warning(f"Trimmed path for {parts[i]}")

--- a/tests/cmd/test_action.py
+++ b/tests/cmd/test_action.py
@@ -1,6 +1,10 @@
 from pathlib import Path
 
-from gtnh_translation_compare.cmd.action import _guidenh_page_to_txloader_path, _make_lang_or_markdown_filetype
+from gtnh_translation_compare.cmd.action import (
+    _guidenh_page_to_txloader_path,
+    _make_lang_or_markdown_filetype,
+    _paratranz_name_key,
+)
 from gtnh_translation_compare.filetypes import FiletypeGuideNhPage, FiletypeLang, FiletypeMarkdownTooltip
 
 GUIDE_PAGE_RELPATH = "resources/GTNH Guide Pack[gregtech]/guidenh/_ru_ru/items_blocks/singleblock_machines.md"
@@ -25,4 +29,22 @@ def test_make_lang_or_markdown_filetype_dispatch() -> None:
     assert isinstance(
         _make_lang_or_markdown_filetype("resources/GregTech[gregtech]/lang/en_US.lang", "item.foo.name=Foo"),
         FiletypeLang,
+    )
+
+
+def test_paratranz_name_key_ignores_renames_that_kept_the_file() -> None:
+    # A leftover file has to match its successor, and the three renames seen so far changed the
+    # case, swapped dashes for underscores, or dropped the "(+3)" ParaTranz once appended.
+    canonical = _paratranz_name_key("resources/Angelica[angelica]/lang/ru_RU.lang.json")
+    assert _paratranz_name_key("resources/Angelica(+3)[angelica]/lang/ru_RU.lang.json") == canonical
+    assert _paratranz_name_key("resources/Witchery++[WitcheryExtras]/lang/ru_RU.lang.json") == _paratranz_name_key(
+        "resources/Witchery++[witcheryextras]/lang/ru_RU.lang.json"
+    )
+    assert _paratranz_name_key(
+        "resources/GTNH Guide Pack[appliedenergistics2]/guidenh/_ru_ru/ae2-mechanics/bytes-and-types.md.json"
+    ) == _paratranz_name_key(
+        "resources/GTNH Guide Pack[appliedenergistics2]/guidenh/_ru_ru/ae2_mechanics/bytes_and_types.md.json"
+    )
+    assert _paratranz_name_key("resources/Angelica[angelica]/lang/ru_RU.lang.json") != _paratranz_name_key(
+        "resources/Avaritia[avaritia]/lang/ru_RU.lang.json"
     )


### PR DESCRIPTION
## Summary
A rename on the mod side leaves the old ParaTranz file in place with its translations, while the sync starts writing to the new name. `Witchery++[WitcheryExtras]` and `Witchery++[witcheryextras]` both exist today, and the guide pack renamed its folders from dashes to underscores between releases, so its old files sit there too.

This adds a read-only `report-paratranz-orphans` command and a manual workflow that lists every ParaTranz file missing from the current daily history, the translated string count in it, and the file that replaced it.

Moving those translations and deleting the leftovers comes next, once the report shows the scale.


## Checklist
- [ ] I have tested this PR in DevEnv
- [ ] I have tested this PR in Fullpack
- [x] This PR is in compliance with the [GTNH AI Policy](https://github.com/GTNewHorizons/GTNH-Dev-Doc/blob/master/AI_POLICY.md)
- [ ] This PR requires another PR in order to merge
